### PR TITLE
Change link target to "_blank"

### DIFF
--- a/js/packages/bene-reader/src/index.tsx
+++ b/js/packages/bene-reader/src/index.tsx
@@ -346,9 +346,9 @@ function Content(props: { navigateEvent: EventTarget }) {
 
         let url = new URL(a.href);
         if (url.host != window.location.host) {
-          // Need to add target="blank" to all anchors, or else external navigation will
+          // Need to add target="_blank" to all anchors, or else external navigation will
           // occur within the reader's iframe.
-          a.setAttribute("target", "blank");
+          a.setAttribute("target", "_blank");
         }
       }
 


### PR DESCRIPTION
This is the special name to cause all new links to open in a new tab/window.
(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target)

I noticed the issue on your demo page when clicking a second link opened it in the same tag the first link had been opened in.  I assume that's not the desired behavior.

This patch assumes that the goal was a new window, but the comments suggest the goal was to avoid the link opening within an iframe.  If that's the case, `_parent` or `_top` could be used instead.