### PR TITLE
ci: Update `actions/checkout` to `v4` from `v3`.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install wasm-pack
         uses: baptiste0928/cargo-install@v2


### PR DESCRIPTION
Internally, this changes it from using Node 16 to 20 as 16 is being deprecated within GitHub Actions in favor of Node 20.